### PR TITLE
Migration to Gtkmm4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.21...3.31)
 Project(latero-gui)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(UNIX)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 endif()
 
 add_subdirectory(src)

--- a/INSTALL
+++ b/INSTALL
@@ -10,7 +10,7 @@ Tested on MacOS Tahoe 26.3.1.
 Install the latero library.
 
 Install dependencies
->> sudo port install gtkmm3 +quartz
+>> sudo port install gtkmm4 +quartz
 
 Build the app
 >> cmake --preset default

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ include(FindPkgConfig)
 
 find_package(latero REQUIRED)
 
-pkg_check_modules (GTKMM gtkmm-3.0 REQUIRED)
+pkg_check_modules (GTKMM gtkmm-4.0 REQUIRED)
 link_directories(${GTKMM_LIBRARY_DIRS})
 include_directories(${GTKMM_INCLUDE_DIRS})
 

--- a/src/TestGui.cpp
+++ b/src/TestGui.cpp
@@ -27,12 +27,11 @@ TestGui::TestGui()
 { 
 	set_title("Latero Tester");
 	auto lateroWidget = Gtk::make_managed<LateroWidget>();
-	lateroWidget->set_margin_left(10);
-	lateroWidget->set_margin_right(10);
+	lateroWidget->set_margin_start(10);
+	lateroWidget->set_margin_end(10);
 	lateroWidget->set_margin_top(10);
 	lateroWidget->set_margin_bottom(10);
-	add(*lateroWidget);
-	show_all_children();
+	set_child(*lateroWidget);
 }
 
 TestGui::~TestGui()

--- a/src/TestGui.h
+++ b/src/TestGui.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <latero/tactiledisplay.h>
 
-class TestGui : public Gtk::Window
+class TestGui : public Gtk::ApplicationWindow
 {
 public:
 

--- a/src/TestGui.h
+++ b/src/TestGui.h
@@ -19,8 +19,7 @@
 //
 // -----------------------------------------------------------
 
-#ifndef TEST_GUI_H
-#define TEST_GUI_H
+#pragma once
 
 #include <gtkmm.h>
 #include <vector>
@@ -34,4 +33,3 @@ public:
 	virtual ~TestGui();
 };
 
-#endif

--- a/src/laterowidget.cpp
+++ b/src/laterowidget.cpp
@@ -57,17 +57,18 @@ LateroWidget::LateroWidget() :
 	// TMP
 
 	auto grid = Gtk::make_managed<Gtk::Grid>();
-	add(*grid);
+	set_child(*grid);
 
 	for (uint y=0; y<dev_->GetFrameSizeY(); ++y)
 	{
 		for (uint x=0; x<dev_->GetFrameSizeX(); ++x)
 		{
             Glib::RefPtr<Gtk::Adjustment> adj = Gtk::Adjustment::create(0, -1, 1, 1, 10, 0);
-            Gtk::Scale* scale = Gtk::make_managed<Gtk::Scale>(Gtk::ORIENTATION_HORIZONTAL);
+            Gtk::Scale* scale = Gtk::make_managed<Gtk::Scale>(Gtk::Orientation::HORIZONTAL);
             scale->set_adjustment(adj);
 			scale->set_size_request(100, -1);
 			scale->set_digits(3);
+			scale->set_draw_value(true);
 		
 			piezoAdj_.push_back(adj);
 			adj->signal_value_changed().connect(sigc::mem_fun(*this, 

--- a/src/laterowidget.h
+++ b/src/laterowidget.h
@@ -19,8 +19,7 @@
 //
 // -----------------------------------------------------------
 
-#ifndef LATERO_WIDGET_H
-#define LATERO_WIDGET_H
+#pragma once
 
 #include <gtkmm.h>
 #include <vector>
@@ -39,4 +38,3 @@ protected:
 	latero::TactileDisplay* dev_;	
 };
 
-#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,5 @@
 int main(int argc, char* argv[])
 {
 	auto app = Gtk::Application::create("org.openlatero.latero-gui");
-	TestGui gui;
-	return app->run(gui);
+	return app->make_window_and_run<TestGui>(argc, argv);
 };


### PR DESCRIPTION
Migrated the entire codebase to use Gtkmm4, without any deprecated calls, along with minor style improvements and bug fixes.